### PR TITLE
feat: Add password decryption function

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -1,7 +1,19 @@
 import bcrypt from 'bcrypt';
 
+import IUser from '../../types/userType';
+
+import User from '../models/user';
+
 export const encryptPassword = async (password: string) => {
   const hashPassword = await bcrypt.hash(password, 12);
 
   return hashPassword;
+};
+
+export const decryptPassword = async (
+  plainPassword: string,
+  hashPass: string
+) => {
+  const result = await bcrypt.compare(plainPassword, hashPass);
+  return result;
 };


### PR DESCRIPTION
Add function to decrypt hashed passwords using bcrypt. This function is used to compare an input password with the hashed password stored in the database. If the input password and hashed password match, it returns a boolean.